### PR TITLE
Solution: Make Debug Logging Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ config :logger,
   level: :debug
 ```
 
+If you want do use the logger in debug-level without the messages from quantum:
+
+```elixir
+config :your_app, YourApp.Scheduler,
+  debug_logging: false
+```
+
 If you encounter any problems with `quantum`, please search if there is already an
   [open issue](https://github.com/quantum-elixir/quantum-core/issues) addressing the problem.
 

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -16,7 +16,8 @@ defmodule Quantum do
     schedule: nil,
     overlap: true,
     timezone: :utc,
-    run_strategy: {Random, :cluster}
+    run_strategy: {Random, :cluster},
+    debug_logging: true
   ]
 
   @doc """

--- a/lib/quantum/executor_supervisor.ex
+++ b/lib/quantum/executor_supervisor.ex
@@ -7,12 +7,17 @@ defmodule Quantum.ExecutorSupervisor do
 
   alias Quantum.Util
 
-  @spec start_link(GenServer.server(), GenServer.server(), GenServer.server(), GenServer.server()) ::
-          GenServer.on_start()
-  def start_link(name, execution_broadcaster, task_supervisor, task_registry) do
+  @spec start_link(
+          GenServer.server(),
+          GenServer.server(),
+          GenServer.server(),
+          GenServer.server(),
+          boolean()
+        ) :: GenServer.on_start()
+  def start_link(name, execution_broadcaster, task_supervisor, task_registry, debug_logging) do
     __MODULE__
     |> ConsumerSupervisor.start_link(
-      {execution_broadcaster, task_supervisor, task_registry},
+      {execution_broadcaster, task_supervisor, task_registry, debug_logging},
       name: name
     )
     |> Util.start_or_link()
@@ -21,17 +26,17 @@ defmodule Quantum.ExecutorSupervisor do
   # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: Remove when gen_stage:0.12 support is dropped
   if Util.gen_stage_v12?() do
-    def init({execution_broadcaster, task_supervisor, task_registry}) do
+    def init({execution_broadcaster, task_supervisor, task_registry, debug_logging}) do
       ConsumerSupervisor.init(
-        {Quantum.Executor, {task_supervisor, task_registry}},
+        {Quantum.Executor, {task_supervisor, task_registry, debug_logging}},
         strategy: :one_for_one,
         subscribe_to: [{execution_broadcaster, max_demand: 50}]
       )
     end
   else
-    def init({execution_broadcaster, task_supervisor, task_registry}) do
+    def init({execution_broadcaster, task_supervisor, task_registry, debug_logging}) do
       ConsumerSupervisor.init(
-        [{Quantum.Executor, {task_supervisor, task_registry}}],
+        [{Quantum.Executor, {task_supervisor, task_registry, debug_logging}}],
         strategy: :one_for_one,
         subscribe_to: [{execution_broadcaster, max_demand: 50}]
       )
@@ -43,15 +48,16 @@ defmodule Quantum.ExecutorSupervisor do
           GenServer.server(),
           GenServer.server(),
           GenServer.server(),
-          GenServer.server()
+          GenServer.server(),
+          boolean()
         }) :: Supervisor.child_spec()
-  def child_spec({name, execution_broadcaster, task_supervisor, task_registry}) do
+  def child_spec({name, execution_broadcaster, task_supervisor, task_registry, debug_logging}) do
     %{
       super([])
       | start: {
           __MODULE__,
           :start_link,
-          [name, execution_broadcaster, task_supervisor, task_registry]
+          [name, execution_broadcaster, task_supervisor, task_registry, debug_logging]
         }
     }
   end

--- a/lib/quantum/job_broadcaster.ex
+++ b/lib/quantum/job_broadcaster.ex
@@ -18,24 +18,25 @@ defmodule Quantum.JobBroadcaster do
    * `jobs` - Array of `Quantum.Job`
 
   """
-  @spec start_link(GenServer.server(), [Job.t()]) :: GenServer.on_start()
-  def start_link(name, jobs) do
+  @spec start_link(GenServer.server(), [Job.t()], boolean()) :: GenServer.on_start()
+  def start_link(name, jobs, debug_logging) do
     __MODULE__
-    |> GenStage.start_link(jobs, name: name)
+    |> GenStage.start_link({jobs, debug_logging}, name: name)
     |> Util.start_or_link()
   end
 
   @doc false
-  @spec child_spec({GenServer.server(), [Job.t()]}) :: Supervisor.child_spec()
-  def child_spec({name, jobs}) do
-    %{super([]) | start: {__MODULE__, :start_link, [name, jobs]}}
+  @spec child_spec({GenServer.server(), [Job.t()], boolean()}) :: Supervisor.child_spec()
+  def child_spec({name, jobs, debug_logging}) do
+    %{super([]) | start: {__MODULE__, :start_link, [name, jobs, debug_logging]}}
   end
 
   @doc false
-  def init(jobs) do
+  def init({jobs, debug_logging}) do
     state = %{
       jobs: Enum.into(jobs, %{}, fn %{name: name} = job -> {name, job} end),
-      buffer: for(%{state: :active} = job <- jobs, do: {:add, job})
+      buffer: for(%{state: :active} = job <- jobs, do: {:add, job}),
+      debug_logging: debug_logging
     }
 
     {:producer, state}
@@ -47,26 +48,35 @@ defmodule Quantum.JobBroadcaster do
     {:noreply, to_send, %{state | buffer: remaining}}
   end
 
-  def handle_cast({:add, %Job{state: :active, name: job_name} = job}, %{jobs: jobs} = state) do
-    Logger.debug(fn ->
-      "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(job_name)}"
-    end)
+  def handle_cast(
+        {:add, %Job{state: :active, name: job_name} = job},
+        %{jobs: jobs, debug_logging: debug_logging} = state
+      ) do
+    debug_logging &&
+      Logger.debug(fn ->
+        "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(job_name)}"
+      end)
 
     {:noreply, [{:add, job}], %{state | jobs: Map.put(jobs, job_name, job)}}
   end
 
-  def handle_cast({:add, %Job{state: :inactive, name: job_name} = job}, %{jobs: jobs} = state) do
-    Logger.debug(fn ->
-      "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(job_name)}"
-    end)
+  def handle_cast(
+        {:add, %Job{state: :inactive, name: job_name} = job},
+        %{jobs: jobs, debug_logging: debug_logging} = state
+      ) do
+    debug_logging &&
+      Logger.debug(fn ->
+        "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(job_name)}"
+      end)
 
     {:noreply, [], %{state | jobs: Map.put(jobs, job_name, job)}}
   end
 
-  def handle_cast({:delete, name}, %{jobs: jobs} = state) do
-    Logger.debug(fn ->
-      "[#{inspect(Node.self())}][#{__MODULE__}] Deleting job #{inspect(name)}"
-    end)
+  def handle_cast({:delete, name}, %{jobs: jobs, debug_logging: debug_logging} = state) do
+    debug_logging &&
+      Logger.debug(fn ->
+        "[#{inspect(Node.self())}][#{__MODULE__}] Deleting job #{inspect(name)}"
+      end)
 
     case Map.fetch(jobs, name) do
       {:ok, %{state: :active}} ->
@@ -80,10 +90,14 @@ defmodule Quantum.JobBroadcaster do
     end
   end
 
-  def handle_cast({:change_state, name, new_state}, %{jobs: jobs} = state) do
-    Logger.debug(fn ->
-      "[#{inspect(Node.self())}][#{__MODULE__}] Change job state #{inspect(name)}"
-    end)
+  def handle_cast(
+        {:change_state, name, new_state},
+        %{jobs: jobs, debug_logging: debug_logging} = state
+      ) do
+    debug_logging &&
+      Logger.debug(fn ->
+        "[#{inspect(Node.self())}][#{__MODULE__}] Change job state #{inspect(name)}"
+      end)
 
     case Map.fetch(jobs, name) do
       :error ->
@@ -105,10 +119,11 @@ defmodule Quantum.JobBroadcaster do
     end
   end
 
-  def handle_cast(:delete_all, %{jobs: jobs} = state) do
-    Logger.debug(fn ->
-      "[#{inspect(Node.self())}][#{__MODULE__}] Deleting all jobs"
-    end)
+  def handle_cast(:delete_all, %{jobs: jobs, debug_logging: debug_logging} = state) do
+    debug_logging &&
+      Logger.debug(fn ->
+        "[#{inspect(Node.self())}][#{__MODULE__}] Deleting all jobs"
+      end)
 
     messages = for {name, %Job{state: :active}} <- jobs, do: {:remove, name}
 

--- a/lib/quantum/task_stages_supervisor.ex
+++ b/lib/quantum/task_stages_supervisor.ex
@@ -32,14 +32,16 @@ defmodule Quantum.TaskStagesSupervisor do
           Quantum.JobBroadcaster,
           {
             Keyword.fetch!(opts, :job_broadcaster),
-            Keyword.fetch!(opts, :jobs)
+            Keyword.fetch!(opts, :jobs),
+            Keyword.fetch!(opts, :debug_logging)
           }
         },
         {
           Quantum.ExecutionBroadcaster,
           {
             Keyword.fetch!(opts, :execution_broadcaster),
-            Keyword.fetch!(opts, :job_broadcaster)
+            Keyword.fetch!(opts, :job_broadcaster),
+            Keyword.fetch!(opts, :debug_logging)
           }
         },
         {
@@ -48,7 +50,8 @@ defmodule Quantum.TaskStagesSupervisor do
             Keyword.fetch!(opts, :executor_supervisor),
             Keyword.fetch!(opts, :execution_broadcaster),
             Keyword.fetch!(opts, :task_supervisor),
-            Keyword.fetch!(opts, :task_registry)
+            Keyword.fetch!(opts, :task_registry),
+            Keyword.fetch!(opts, :debug_logging)
           }
         }
       ],

--- a/test/quantum/execution_broadcaster_test.exs
+++ b/test/quantum/execution_broadcaster_test.exs
@@ -23,10 +23,10 @@ defmodule Quantum.ExecutionBroadcasterTest do
 
   setup do
     {:ok, producer} = start_supervised({TestProducer, []})
-    {:ok, broadcaster} = start_supervised({ExecutionBroadcaster, {__MODULE__, producer}})
+    {:ok, broadcaster} = start_supervised({ExecutionBroadcaster, {__MODULE__, producer, true}})
     {:ok, _consumer} = start_supervised({TestConsumer, [broadcaster, self()]})
 
-    {:ok, %{producer: producer, broadcaster: broadcaster}}
+    {:ok, %{producer: producer, broadcaster: broadcaster, debug_logging: true}}
   end
 
   describe "add" do
@@ -143,8 +143,8 @@ defmodule Quantum.ExecutionBroadcasterTest do
       end)
     end
 
-    test "DST creates no problems" do
-      state = %{jobs: [], time: ~N[2018-03-25 00:59:01], timer: nil}
+    test "DST creates no problems", %{debug_logging: debug_logging} do
+      state = %{jobs: [], time: ~N[2018-03-25 00:59:01], timer: nil, debug_logging: debug_logging}
 
       job =
         TestScheduler.new_job()


### PR DESCRIPTION
_See also #331_

With this new configuration_option `debug_logging: false` (defaults to `true`) you can mute the Quantum debug-messages (if you want to use the `debug`-level of Logger for your own stuff). 