### PR TITLE
Solution: Add helpers for querying task registry

### DIFF
--- a/test/quantum/task_registry_test.exs
+++ b/test/quantum/task_registry_test.exs
@@ -5,7 +5,8 @@ defmodule Quantum.TaskRegistryTest do
 
   alias Quantum.TaskRegistry
 
-  doctest TaskRegistry, except: [mark_running: 3, mark_finished: 3]
+  doctest TaskRegistry,
+    except: [mark_running: 3, mark_finished: 3, is_running?: 2, any_running?: 1]
 
   setup do
     {:ok, registry} = start_supervised({TaskRegistry, __MODULE__})
@@ -42,6 +43,35 @@ defmodule Quantum.TaskRegistryTest do
       task = make_ref()
 
       assert :ok = TaskRegistry.mark_finished(registry, task, self())
+    end
+  end
+
+  describe "is_running?" do
+    test "not running", %{registry: registry} do
+      task = make_ref()
+      assert false == TaskRegistry.is_running?(registry, task)
+    end
+
+    test "running", %{registry: registry} do
+      task = make_ref()
+
+      TaskRegistry.mark_running(registry, task, self())
+
+      assert true == TaskRegistry.is_running?(registry, task)
+    end
+  end
+
+  describe "any_running?" do
+    test "not running", %{registry: registry} do
+      assert false == TaskRegistry.any_running?(registry)
+    end
+
+    test "running", %{registry: registry} do
+      task = make_ref()
+
+      TaskRegistry.mark_running(registry, task, self())
+
+      assert true == TaskRegistry.any_running?(registry)
     end
   end
 end


### PR DESCRIPTION
Closes: #344 

This PR adds functions for querying task registry if specific task is running in the cluster or if any tasks are running.

I have a question about doctests. All documented functions with examples in `TaskRegistry` module have doctests disabled. I followed what is currently there and listed the two new functions in `except`. Shall I delete doctests for this module or do you want to have them enabled and listed all functions in except?

Thanks for your time reviewing the changes!