### PR TITLE
Solution: Properly handle InvalidDateTimeForTimezoneError for newest timex version

### DIFF
--- a/lib/quantum/date_library/timex.ex
+++ b/lib/quantum/date_library/timex.ex
@@ -42,6 +42,13 @@ if Code.ensure_compiled?(Timex) do
       date
       |> Timex.to_datetime(tz)
       |> Timezone.convert("Etc/UTC")
+      |> case do
+        {:error, :invalid_date} ->
+          raise InvalidDateTimeForTimezoneError
+
+        %DateTime{} = date ->
+          date
+      end
       |> DateTime.to_naive()
       |> check_same(date, tz)
     end


### PR DESCRIPTION
Fix for Test failure observed in #383 