### PR TITLE
Fixes typo in scheduler docs

### DIFF
--- a/lib/quantum/scheduler.ex
+++ b/lib/quantum/scheduler.ex
@@ -14,7 +14,7 @@ defmodule Quantum.Scheduler do
 
       config :my_app, MyApp.Scheduler,
         jobs: [
-          {"@daily", {Backup, :backup, []},
+          {"@daily", {Backup, :backup, []}},
         ]
 
   ## Configuration:


### PR DESCRIPTION
Sorry not to bundle it together with #400 but I have just noticed it.