### PR TITLE
Solution: make state configurable when defining the config

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -13,6 +13,7 @@ defmodule Quantum do
     timeout: 5_000,
     schedule: nil,
     overlap: true,
+    state: :active,
     timezone: :utc,
     run_strategy: {Random, :cluster},
     debug_logging: true

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -63,13 +63,15 @@ defmodule Quantum.Job do
          overlap when is_boolean(overlap) <- Keyword.fetch!(config, :overlap),
          timezone when timezone == :utc or is_binary(timezone) <-
            Keyword.fetch!(config, :timezone),
+         state when is_atom(state) <- Keyword.fetch!(config, :state),
          schedule <- Keyword.get(config, :schedule) do
       %__MODULE__{
         name: name,
         overlap: Keyword.fetch!(config, :overlap),
         timezone: Keyword.fetch!(config, :timezone),
         run_strategy: run_strategy,
-        schedule: schedule
+        schedule: schedule,
+        state: state
       }
     end
   end

--- a/test/quantum/job_test.exs
+++ b/test/quantum/job_test.exs
@@ -20,4 +20,11 @@ defmodule Quantum.JobTest do
 
     assert %Job{schedule: ^schedule, overlap: false} = Job.new(configs)
   end
+
+  test "is is possible to initialize a job as inactive" do
+    configs = Scheduler.config(schedule: "*/7", overlap: false, state: :inactive)
+    schedule = ~e[*/7]
+
+    assert %Job{schedule: ^schedule, overlap: false, state: :inactive} = Job.new(configs)
+  end
 end


### PR DESCRIPTION
This commit adds to ability to define a job in a config as being inactive when initialising. This can be useful when you want to define certain jobs that you want to set active in the app at runtime without the need to configure the whole job at runtime.