### PR TITLE
Yordis/improve docs

### DIFF
--- a/lib/quantum/scheduler.ex
+++ b/lib/quantum/scheduler.ex
@@ -54,7 +54,7 @@ defmodule Quantum.Scheduler do
       @otp_app Keyword.fetch!(opts, :otp_app)
       @moduledoc moduledoc
                  |> String.replace(~r/MyApp\.Scheduler/, Enum.join(Module.split(__MODULE__), "."))
-                 |> String.replace(~r/:my_app/, ":" <> @otp_app)
+                 |> String.replace(~r/:my_app/, ":" <> Atom.to_string(@otp_app))
 
       @behaviour Quantum.Scheduler
 


### PR DESCRIPTION
Converting an atom to a string does not preserve the colon. The documentation is generating invalid Elixir code.