### PR TITLE
Adds QuantumStorageMnesia as a Quantum.Storage alternative

### DIFF
--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -37,6 +37,7 @@ Storage implementations must implement the `Quantum.Storage` behaviour.
 The following adapters are supported:
 
 * [`PersistentEts`](https://hex.pm/packages/quantum_storage_persistent_ets)
+* [`Mnesia`](https://hex.pm/packages/quantum_storage_mnesia)
 
 ## Release managers
 (


### PR DESCRIPTION
As requested in #438, This PR adds `QuantumStorageMnesia` as a option to `Quantum.Storage`.