### PR TITLE
Fixes catch-up events creation in reverse order

### DIFF
--- a/lib/quantum/clock_broadcaster.ex
+++ b/lib/quantum/clock_broadcaster.ex
@@ -72,6 +72,8 @@ defmodule Quantum.ClockBroadcaster do
         end
       )
 
+    events = Enum.reverse(events)
+
     new_remaining_demand = expected_event_count - Enum.count(events)
 
     if remaining_demand > 0 and new_remaining_demand == 0 do


### PR DESCRIPTION
The PR fixes ClockBroadcaster catch-up events creation order discussed in #441 