### PR TITLE
feat: Handles task failures by returning a value

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -84,20 +84,25 @@ defmodule Quantum.Executor do
           "[#{inspect(Node.self())}][#{__MODULE__}] Execute started for job #{inspect(job_name)}"
         end)
 
-      result = 
-        try do
-          execute_task(task)
-        catch
-          type, value ->
-            {type, value}
-        end
-
-      debug_logging &&
-        Logger.debug(fn ->
-          "[#{inspect(Node.self())}][#{__MODULE__}] Execution ended for job #{inspect(job_name)}, which yielded result: #{
-            inspect(result)
-          }"
-        end)
+      try do
+        execute_task(task)
+      catch
+        type, value ->
+          debug_logging &&
+            Logger.debug(fn ->
+              "[#{inspect(Node.self())}][#{__MODULE__}] Execution ended for job #{
+                inspect(job_name)
+              }, which failed due to: #{Exception.format(type, value, __STACKTRACE__)}"
+            end)
+      else
+        result ->
+          debug_logging &&
+            Logger.debug(fn ->
+              "[#{inspect(Node.self())}][#{__MODULE__}] Execution ended for job #{
+                inspect(job_name)
+              }, which yielded result: #{inspect(result)}"
+            end)
+      end
 
       :ok
     end)

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -84,7 +84,13 @@ defmodule Quantum.Executor do
           "[#{inspect(Node.self())}][#{__MODULE__}] Execute started for job #{inspect(job_name)}"
         end)
 
-      result = execute_task(task)
+      result = 
+        try do
+          execute_task(task)
+        catch
+          type, value ->
+            {type, value}
+        end
 
       debug_logging &&
         Logger.debug(fn ->


### PR DESCRIPTION
Right now, a value is not always returned, as exits, exceptions, and thrown values are not handled inside the task.

This ensures a value is always returned.