### PR TITLE
Supervision Configuration for Cluster Managers

### DIFF
--- a/lib/quantum/executor_supervisor.ex
+++ b/lib/quantum/executor_supervisor.ex
@@ -11,8 +11,8 @@ defmodule Quantum.ExecutorSupervisor do
 
   @spec start_link(StartOpts.t()) :: GenServer.on_start()
   def start_link(%StartOpts{name: name} = opts) do
-    ConsumerSupervisor.start_link(
-      __MODULE__,
+    __MODULE__
+    |> ConsumerSupervisor.start_link(
       struct!(
         InitOpts,
         Map.take(opts, [
@@ -24,6 +24,17 @@ defmodule Quantum.ExecutorSupervisor do
       ),
       name: name
     )
+    |> case do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, pid}} ->
+        Process.monitor(pid)
+        {:ok, pid}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   @impl ConsumerSupervisor

--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -25,7 +25,8 @@ defmodule Quantum.Normalizer do
   #
   #   * `base` - Empty `Quantum.Job`
   #   * `job` - The Job To Normalize
-  @spec normalize(Job.t(), config_full_notation | config_short_notation) :: Job.t() | no_return
+  @spec normalize(Job.t(), config_full_notation | config_short_notation | Job.t()) ::
+          Job.t() | no_return
   def normalize(base, job)
 
   def normalize(%Job{} = base, job) when is_list(job) do
@@ -48,6 +49,10 @@ defmodule Quantum.Normalizer do
 
   def normalize(%Job{} = base, {schedule, task}) do
     normalize_options(base, %{schedule: schedule, task: task})
+  end
+
+  def normalize(%Job{} = _base, %Job{} = job) do
+    job
   end
 
   @spec normalize_options(Job.t(), map) :: Job.t()


### PR DESCRIPTION
Allows Implementation of #411

This allows new libraries that start quantum on its own terms. Even the central `Supervisor` can be overwritten to allow full control.

For better handling with restarts, implementations could also provide a default `storage` that provides ephemeral storage inside the cluster. This would keep the storage as long as not all nodes in the cluster are restarted at the same time.