### PR TITLE
Uses logger metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,2 +1,3 @@
 use Mix.Config
+config :logger, :console, metadata: :all
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase

--- a/lib/quantum/clock_broadcaster.ex
+++ b/lib/quantum/clock_broadcaster.ex
@@ -118,6 +118,6 @@ defmodule Quantum.ClockBroadcaster do
   defp log_catched_up(%State{debug_logging: true}),
     do:
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Clock Producer catched up with past times and is now running in normal time"
+        {"Clock Producer catched up with past times and is now running in normal time", node: Node.self()}
       end)
 end

--- a/lib/quantum/clock_broadcaster.ex
+++ b/lib/quantum/clock_broadcaster.ex
@@ -118,6 +118,7 @@ defmodule Quantum.ClockBroadcaster do
   defp log_catched_up(%State{debug_logging: true}),
     do:
       Logger.debug(fn ->
-        {"Clock Producer catched up with past times and is now running in normal time", node: Node.self()}
+        {"Clock Producer catched up with past times and is now running in normal time",
+         node: Node.self()}
       end)
 end

--- a/lib/quantum/execution_broadcaster.ex
+++ b/lib/quantum/execution_broadcaster.ex
@@ -216,7 +216,7 @@ defmodule Quantum.ExecutionBroadcaster do
           for %Job{name: job_name} = job <- jobs do
             debug_logging &&
               Logger.debug(fn ->
-                {"Scheduling job for execution", node: Node.self(), name: name}
+                {"Scheduling job for execution", node: Node.self(), name: job_name}
               end)
 
             %ExecuteEvent{job: job}

--- a/lib/quantum/execution_broadcaster.ex
+++ b/lib/quantum/execution_broadcaster.ex
@@ -101,9 +101,7 @@ defmodule Quantum.ExecutionBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Scheduling job for single reboot execution: #{
-          inspect(name)
-        }"
+        {"Scheduling job for single reboot execution", node: Node.self(), name: name}
       end)
 
     {[%ExecuteEvent{job: job}], %{state | uninitialized_jobs: [job | uninitialized_jobs]}}
@@ -115,7 +113,7 @@ defmodule Quantum.ExecutionBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(name)}"
+        {"Adding job", node: Node.self(), name: name}
       end)
 
     {[], %{state | uninitialized_jobs: [job | uninitialized_jobs]}}
@@ -127,7 +125,7 @@ defmodule Quantum.ExecutionBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Running job #{inspect(name)} once"
+        {"Running job once", node: Node.self(), name: name}
       end)
 
     {[%ExecuteEvent{job: job}], state}
@@ -143,7 +141,7 @@ defmodule Quantum.ExecutionBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Removing job #{inspect(name)}"
+        {"Removing job", node: Node.self(), name: name}
       end)
 
     uninitialized_jobs = Enum.reject(uninitialized_jobs, &(&1.name == name))
@@ -218,9 +216,7 @@ defmodule Quantum.ExecutionBroadcaster do
           for %Job{name: job_name} = job <- jobs do
             debug_logging &&
               Logger.debug(fn ->
-                "[#{inspect(Node.self())}][#{__MODULE__}] Scheduling job for execution #{
-                  inspect(job_name)
-                }"
+                {"Scheduling job for execution", node: Node.self(), name: name}
               end)
 
             %ExecuteEvent{job: job}

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -51,7 +51,7 @@ defmodule Quantum.Executor do
        ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Start execution of job #{inspect(job_name)}"
+        {"Start execution of job", node: Node.self(), name: job_name}
       end)
 
     case TaskRegistry.mark_running(task_registry, job_name, node) do
@@ -84,15 +84,13 @@ defmodule Quantum.Executor do
        ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Task for job #{inspect(job_name)} started on node #{
-          node
-        }"
+        {"Task for job started on node", node: Node.self(), name: job_name, started_on: node}
       end)
 
     Task.Supervisor.async_nolink({task_supervisor, node}, fn ->
       debug_logging &&
         Logger.debug(fn ->
-          "[#{inspect(Node.self())}][#{__MODULE__}] Execute started for job #{inspect(job_name)}"
+          {"Execute started for job", node: Node.self(), name: job_name}
         end)
 
       # Note: we are intentionally mimicking the ":telemetry.span" here to keep current functionality
@@ -110,9 +108,13 @@ defmodule Quantum.Executor do
         type, value ->
           debug_logging &&
             Logger.debug(fn ->
-              "[#{inspect(Node.self())}][#{__MODULE__}] Execution ended for job #{
-                inspect(job_name)
-              }, which failed due to: #{Exception.format(type, value, __STACKTRACE__)}"
+              {
+                "Execution failed for job",
+                node: Node.self(),
+                name: job_name,
+                type: type,
+                value: value
+              }
             end)
 
           duration = :erlang.monotonic_time() - start_monotonic_time
@@ -128,9 +130,7 @@ defmodule Quantum.Executor do
         result ->
           debug_logging &&
             Logger.debug(fn ->
-              "[#{inspect(Node.self())}][#{__MODULE__}] Execution ended for job #{
-                inspect(job_name)
-              }, which yielded result: #{inspect(result)}"
+              {"Execution ended for job", node: Node.self(), name: job_name, result: result}
             end)
 
           duration = :erlang.monotonic_time() - start_monotonic_time

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -110,10 +110,7 @@ defmodule Quantum.Executor do
             Logger.debug(fn ->
               {
                 "Execution failed for job",
-                node: Node.self(),
-                name: job_name,
-                type: type,
-                value: value
+                node: Node.self(), name: job_name, type: type, value: value
               }
             end)
 

--- a/lib/quantum/job_broadcaster.ex
+++ b/lib/quantum/job_broadcaster.ex
@@ -227,7 +227,7 @@ defmodule Quantum.JobBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        {"Deleting job", node: Node.self(), name: job_name}
+        {"Deleting job", node: Node.self(), name: name}
       end)
 
     case Map.fetch(jobs, name) do

--- a/lib/quantum/job_broadcaster.ex
+++ b/lib/quantum/job_broadcaster.ex
@@ -49,7 +49,7 @@ defmodule Quantum.JobBroadcaster do
         :not_applicable ->
           debug_logging &&
             Logger.debug(fn ->
-              "[#{inspect(Node.self())}][#{__MODULE__}] Loading Initial Jobs from Config"
+              {"Loading Initial Jobs from Config", node: Node.self()}
             end)
 
           jobs
@@ -57,7 +57,7 @@ defmodule Quantum.JobBroadcaster do
         storage_jobs when is_list(storage_jobs) ->
           debug_logging &&
             Logger.debug(fn ->
-              "[#{inspect(Node.self())}][#{__MODULE__}] Loading Initial Jobs from Storage, skipping config"
+              {"Loading Initial Jobs from Storage, skipping config", node: Node.self()}
             end)
 
           for %Job{state: :active} = job <- storage_jobs do
@@ -104,7 +104,7 @@ defmodule Quantum.JobBroadcaster do
       %{^job_name => %Job{state: :active} = old_job} ->
         debug_logging &&
           Logger.debug(fn ->
-            "[#{inspect(Node.self())}][#{__MODULE__}] Replacing job #{inspect(job_name)}"
+            {"Replacing job", node: Node.self(), name: job_name}
           end)
 
         # Send event to telemetry incase the end user wants to monitor events
@@ -122,7 +122,7 @@ defmodule Quantum.JobBroadcaster do
       %{^job_name => %Job{state: :inactive}} ->
         debug_logging &&
           Logger.debug(fn ->
-            "[#{inspect(Node.self())}][#{__MODULE__}] Replacing job #{inspect(job_name)}"
+            {"Replacing job", node: Node.self(), name: job_name}
           end)
 
         # Send event to telemetry incase the end user wants to monitor events
@@ -139,7 +139,7 @@ defmodule Quantum.JobBroadcaster do
       _ ->
         debug_logging &&
           Logger.debug(fn ->
-            "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(job_name)}"
+            {"Adding job", node: Node.self(), name: job_name}
           end)
 
         # Send event to telemetry incase the end user wants to monitor events
@@ -167,7 +167,7 @@ defmodule Quantum.JobBroadcaster do
       %{^job_name => %Job{state: :active} = old_job} ->
         debug_logging &&
           Logger.debug(fn ->
-            "[#{inspect(Node.self())}][#{__MODULE__}] Replacing job #{inspect(job_name)}"
+            {"Replacing job", node: Node.self(), name: job_name}
           end)
 
         # Send event to telemetry incase the end user wants to monitor events
@@ -184,7 +184,7 @@ defmodule Quantum.JobBroadcaster do
       %{^job_name => %Job{state: :inactive}} ->
         debug_logging &&
           Logger.debug(fn ->
-            "[#{inspect(Node.self())}][#{__MODULE__}] Replacing job #{inspect(job_name)}"
+            {"Replacing job", node: Node.self(), name: job_name}
           end)
 
         # Send event to telemetry incase the end user wants to monitor events
@@ -201,7 +201,7 @@ defmodule Quantum.JobBroadcaster do
       _ ->
         debug_logging &&
           Logger.debug(fn ->
-            "[#{inspect(Node.self())}][#{__MODULE__}] Adding job #{inspect(job_name)}"
+            {"Adding job", node: Node.self(), name: job_name}
           end)
 
         # Send event to telemetry incase the end user wants to monitor events
@@ -227,7 +227,7 @@ defmodule Quantum.JobBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Deleting job #{inspect(name)}"
+        {"Deleting job", node: Node.self(), name: job_name}
       end)
 
     case Map.fetch(jobs, name) do
@@ -269,7 +269,7 @@ defmodule Quantum.JobBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Change job state #{inspect(name)}"
+        {"Change job state", node: Node.self(), name: name}
       end)
 
     case Map.fetch(jobs, name) do
@@ -309,7 +309,7 @@ defmodule Quantum.JobBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Running job #{inspect(name)} once"
+        {"Running job once", node: Node.self(), name: name}
       end)
 
     case Map.fetch(jobs, name) do
@@ -332,7 +332,7 @@ defmodule Quantum.JobBroadcaster do
       ) do
     debug_logging &&
       Logger.debug(fn ->
-        "[#{inspect(Node.self())}][#{__MODULE__}] Deleting all jobs"
+        {"Deleting all jobs", node: Node.self()}
       end)
 
     for {_name, %Job{} = job} <- jobs do

--- a/lib/quantum/supervisor.ex
+++ b/lib/quantum/supervisor.ex
@@ -3,8 +3,6 @@ defmodule Quantum.Supervisor do
 
   use Supervisor
 
-  require Logger
-
   # Starts the quantum supervisor.
   @spec start_link(GenServer.server(), Keyword.t()) :: GenServer.on_start()
   def start_link(quantum, opts) do

--- a/lib/quantum/task_registry.ex
+++ b/lib/quantum/task_registry.ex
@@ -3,8 +3,6 @@ defmodule Quantum.TaskRegistry do
 
   # Registry to check if a task is already running on a node.
 
-  require Logger
-
   alias __MODULE__.StartOpts
   alias Quantum.Job
 

--- a/test/quantum/executor_test.exs
+++ b/test/quantum/executor_test.exs
@@ -359,7 +359,8 @@ defmodule Quantum.ExecutorTest do
           assert :ok == wait_for_termination(task)
         end)
 
-      assert logs =~ ~r/\(RuntimeError\) failed/
+      assert logs =~ ~r/type=error/
+      assert logs =~ ~r/Execution failed for job/
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{
@@ -408,7 +409,7 @@ defmodule Quantum.ExecutorTest do
           assert :ok == wait_for_termination(task)
         end)
 
-      assert logs =~ ~r/\(exit\) :failure/
+      assert logs =~ ~r/type=exit value=failure/
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{
@@ -459,7 +460,8 @@ defmodule Quantum.ExecutorTest do
           assert :ok == wait_for_termination(task)
         end)
 
-      assert logs =~ "(throw) #{inspect(ref)}"
+      '#Ref' ++ rest = :erlang.ref_to_list(ref)
+      assert logs =~ "type=throw value=#{rest}"
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{

--- a/test/quantum/executor_test.exs
+++ b/test/quantum/executor_test.exs
@@ -409,7 +409,8 @@ defmodule Quantum.ExecutorTest do
           assert :ok == wait_for_termination(task)
         end)
 
-      assert logs =~ ~r/type=exit value=failure/
+      assert logs =~ ~r/type=exit/
+      assert logs =~ ~r/value=failure/
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{
@@ -461,7 +462,8 @@ defmodule Quantum.ExecutorTest do
         end)
 
       '#Ref' ++ rest = :erlang.ref_to_list(ref)
-      assert logs =~ "type=throw value=#{rest}"
+      assert logs =~ "type=throw"
+      assert logs =~ "value=#{rest}"
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{

--- a/test/quantum/job_broadcaster_test.exs
+++ b/test/quantum/job_broadcaster_test.exs
@@ -182,7 +182,7 @@ defmodule Quantum.JobBroadcasterTest do
                assert_receive {:received, {:add, ^active_job}}
 
                assert_receive {:add_job, ^active_job, _}
-             end) =~ "Adding job #Reference"
+             end) =~ "Adding job"
 
       assert_receive %{test_id: ^test_id}
     end


### PR DESCRIPTION
Fixes #460 

I have replaced the uses of dynamic messages in debug logs with static messages with dynamic logger metadata.