### PR TITLE
Support setting job `state` in scheduler's config

### DIFF
--- a/lib/quantum/normalizer.ex
+++ b/lib/quantum/normalizer.ex
@@ -85,6 +85,10 @@ defmodule Quantum.Normalizer do
     Job.set_timezone(job, normalize_timezone(timezone))
   end
 
+  defp normalize_job_option({:state, state}, job) do
+    Job.set_state(job, state)
+  end
+
   defp normalize_job_option(_, job), do: job
 
   @spec normalize_task(config_task) :: Job.task() | no_return

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -15,7 +15,7 @@ config :your_app, YourApp.Scheduler,
     # Runs on 18, 20, 22, 0, 2, 4, 6:
     {"0 18-6/2 * * *",         fn -> :mnesia.backup('/var/backup/mnesia') end},
     # Runs every midnight:
-    {"@daily",                 {Backup, :backup, []}}
+    {"@daily",                 {Backup, :backup, []}, state: :inactive}
   ]
 ```
 
@@ -72,6 +72,7 @@ Possible options:
 - `task` function to be performed, ex: `{Heartbeat, :send, []}` or `fn -> :something end`
 - `run_strategy` strategy on how to run tasks inside of cluster, default: `%Quantum.RunStrategy.Random{nodes: :cluster}`
 - `overlap` set to false to prevent next job from being executed if previous job is still running, default: `true`
+- `state` set to `:inactive` to deactivate a job or `:active` to activate it
 
 It is possible to control the behavior of jobs at runtime.
 

--- a/test/quantum/normalizer_test.exs
+++ b/test/quantum/normalizer_test.exs
@@ -74,6 +74,22 @@ defmodule Quantum.NormalizerTest do
     assert normalize(Scheduler.new_job(), job) == expected_job
   end
 
+  test "normalizer of state" do
+    job = {
+      :newsletter,
+      [
+        state: :inactive
+      ]
+    }
+
+    expected_job =
+      Scheduler.new_job()
+      |> Job.set_name(:newsletter)
+      |> Job.set_state(:inactive)
+
+    assert normalize(Scheduler.new_job(), job) == expected_job
+  end
+
   test "expression tuple not extended" do
     job = {
       :newsletter,

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -19,6 +19,7 @@ defmodule QuantumStartupTest do
       test_jobs = [
         {:test_job, [schedule: ~e[1 * * * *], task: fn -> :ok end]},
         {:test_job, [schedule: ~e[2 * * * *], task: fn -> :ok end]},
+        {:inactive_job, [schedule: ~e[* * * * *], task: fn -> :ok end, state: :inactive]},
         {"3 * * * *", fn -> :ok end},
         {"4 * * * *", fn -> :ok end}
       ]
@@ -28,8 +29,9 @@ defmodule QuantumStartupTest do
       capture_log(fn ->
         {:ok, _pid} = start_supervised(Scheduler)
 
-        assert Enum.count(QuantumStartupTest.Scheduler.jobs()) == 3
+        assert Enum.count(QuantumStartupTest.Scheduler.jobs()) == 4
         assert QuantumStartupTest.Scheduler.find_job(:test_job).schedule == ~e[1 * * * *]
+        assert QuantumStartupTest.Scheduler.find_job(:inactive_job).state == :inactive
 
         :ok = stop_supervised(Scheduler)
       end)


### PR DESCRIPTION
Currently job `state` cannot be set through config. This is useful if we wish to start with jobs deactivated and activate them on runtime.