### PR TITLE
Log exception with crash_reason

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -159,10 +159,11 @@ defmodule Quantum.Executor do
   def log_exception(kind, reason, stacktrace) do
     reason = Exception.normalize(kind, reason, stacktrace)
 
-    crash_reason = case kind do
-      :throw -> {{:nocatch, reason}, stacktrace}
-      _ -> {reason, stacktrace}
-    end
+    crash_reason =
+      case kind do
+        :throw -> {{:nocatch, reason}, stacktrace}
+        _ -> {reason, stacktrace}
+      end
 
     Logger.error(
       Exception.format(kind, reason, stacktrace),

--- a/test/quantum/executor_test.exs
+++ b/test/quantum/executor_test.exs
@@ -411,6 +411,7 @@ defmodule Quantum.ExecutorTest do
 
       assert logs =~ ~r/type=exit/
       assert logs =~ ~r/value=failure/
+      assert logs =~ "[error] ** (exit) :failure"
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{


### PR DESCRIPTION
Thanks for the amazing work on this package! Super helpful.

I ran into two issues:

* In production, when a job was failing, I wasn't getting any errors logged
* Additionally, none of these failures were being reported to my error monitoring (sentry)

Here's what I found:

* The reason I was't getting any errors logged was because I have my log level set to `info`. I'd expect most deployments to use a non-info log level.
* An exception from a scheduled job shouldn't be a `debug` log but instead should use something like `error`.
* If you are using an exception logging system such as sentry, you need `crash_reason` to exist in your log metadata for the log message to be treated as an exception. Here's an [example implementation in broadway](https://github.com/dashbitco/broadway/blob/master/lib/broadway/topology/processor_stage.ex#L165-L179)

This change fixes both of these problems.

I've submitted a proposal to elixir-lang to get this function included in the stdlib: https://groups.google.com/g/elixir-lang-core/c/pWz-uTVMEVM