### PR TITLE
Optional `update_job` callback in `Quantum.Storage`

### DIFF
--- a/lib/quantum/storage.ex
+++ b/lib/quantum/storage.ex
@@ -76,4 +76,14 @@ defmodule Quantum.Storage do
   Purge all date from storage and go back to initial state.
   """
   @callback purge(storage_pid :: storage_pid) :: :ok
+
+  @doc """
+  Updates existing job in storage.
+
+  This callback is optional. If not implemented then the `c:delete_job/2`
+  and then the `c:add_job/2` callbacks will be called instead.
+  """
+  @callback update_job(storage_pid :: storage_pid, job :: Job.t()) :: :ok
+
+  @optional_callbacks update_job: 2
 end

--- a/test/support/test_storage.ex
+++ b/test/support/test_storage.ex
@@ -114,3 +114,13 @@ defmodule Quantum.Storage.Test do
     end
   end
 end
+
+defmodule Quantum.Storage.TestWithUpdate do
+  @moduledoc """
+  Test implementation of a `Quantum.Storage` that overrides `c:update_job/2`.
+  """
+  use Quantum.Storage.Test
+
+  @impl Quantum.Storage
+  def update_job(_storage_pid, job), do: send_and_wait(:update_job, job)
+end


### PR DESCRIPTION
Add an optional `update_job` callback in `Quantum.Storage`. If this is implemented then it will be called when a job gets updated, otherwise the previous behaviour (delete and then add the job) will be used.

Rationale: I have created a `postgres` storage and the jobs are linked to other tables through foreign keys. With the current implementation every time a job is updated it deletes the current job and adds it again. I want to be able to just update the properties that have changed and leave everything else untouched.