### PR TITLE
Fix tests and resolve a bug in ExecutionBroadcaster

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
-config :logger, :console, metadata: :all
+config :logger, :console, metadata: [:all, :crash_reason]
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase

--- a/lib/quantum/execution_broadcaster.ex
+++ b/lib/quantum/execution_broadcaster.ex
@@ -263,6 +263,8 @@ defmodule Quantum.ExecutionBroadcaster do
         job: job,
         error: e
       )
+
+      state
   end
 
   defp get_next_execution_time(

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -159,15 +159,8 @@ defmodule Quantum.Executor do
   def log_exception(kind, reason, stacktrace) do
     reason = Exception.normalize(kind, reason, stacktrace)
 
-    crash_reason =
-      case kind do
-        :throw -> {{:nocatch, reason}, stacktrace}
-        _ -> {reason, stacktrace}
-      end
-
     Logger.error(
-      Exception.format(kind, reason, stacktrace),
-      crash_reason: crash_reason
+      Exception.format(kind, reason, stacktrace)
     )
   end
 end

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -159,8 +159,6 @@ defmodule Quantum.Executor do
   def log_exception(kind, reason, stacktrace) do
     reason = Exception.normalize(kind, reason, stacktrace)
 
-    Logger.error(
-      Exception.format(kind, reason, stacktrace)
-    )
+    Logger.error(Exception.format(kind, reason, stacktrace))
   end
 end

--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -159,6 +159,20 @@ defmodule Quantum.Executor do
   def log_exception(kind, reason, stacktrace) do
     reason = Exception.normalize(kind, reason, stacktrace)
 
-    Logger.error(Exception.format(kind, reason, stacktrace))
+    # TODO: Remove in a future version and make elixir 1.10 minimum requirement
+    if Version.match?(System.version(), "< 1.10.0") do
+      Logger.error(Exception.format(kind, reason, stacktrace))
+    else
+      crash_reason =
+        case kind do
+          :throw -> {{:nocatch, reason}, stacktrace}
+          _ -> {reason, stacktrace}
+        end
+
+      Logger.error(
+        Exception.format(kind, reason, stacktrace),
+        crash_reason: crash_reason
+      )
+    end
   end
 end

--- a/test/quantum/executor_test.exs
+++ b/test/quantum/executor_test.exs
@@ -359,7 +359,7 @@ defmodule Quantum.ExecutorTest do
           assert :ok == wait_for_termination(task)
         end)
 
-      assert logs =~ ~r/type=error/
+      assert logs =~ ~r/[error]/
       assert logs =~ ~r/Execution failed for job/
       assert_receive %{test_id: ^test_id, type: :start}
 
@@ -409,8 +409,6 @@ defmodule Quantum.ExecutorTest do
           assert :ok == wait_for_termination(task)
         end)
 
-      assert logs =~ ~r/type=exit/
-      assert logs =~ ~r/value=failure/
       assert logs =~ "[error] ** (exit) :failure"
       assert_receive %{test_id: ^test_id, type: :start}
 
@@ -463,8 +461,8 @@ defmodule Quantum.ExecutorTest do
         end)
 
       '#Ref' ++ rest = :erlang.ref_to_list(ref)
-      assert logs =~ "type=throw"
-      assert logs =~ "value=#{rest}"
+      assert logs =~ "[error] ** (throw)"
+      assert logs =~ "#{rest}"
       assert_receive %{test_id: ^test_id, type: :start}
 
       assert_receive %{


### PR DESCRIPTION
Includes the following changes:

- Make all tests work again (#466) (had to include `:crash_reason` in logger metadata, and remove the custom `:crash_reason` from `log_exception`
- Fix a bug in `ExecutionBroadcaster` . In case of invalid timezone no `state` was returned and as a result the `GenServer` was crashing:

```
22:41:29.638 [error] Invalid Timezone "foobar" provided for job :test.
22:41:29.655 [error] GenServer Jobex.Scheduler.ExecutionBroadcaster terminating
** (FunctionClauseError) no function clause matching in Quantum.ExecutionBroadcaster.sort_state/1
    (quantum) lib/quantum/execution_broadcaster.ex:299: Quantum.ExecutionBroadcaster.sort_state(:ok)
    (quantum) lib/quantum/execution_broadcaster.ex:170: Quantum.ExecutionBroadcaster.handle_event/2
    (quantum) lib/quantum/execution_broadcaster.ex:91: anonymous fn/2 in Quantum.ExecutionBroadcaster.handle_events/3
    (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
    (quantum) lib/quantum/execution_broadcaster.ex:90: Quantum.ExecutionBroadcaster.handle_events/3
    (gen_stage) lib/gen_stage.ex:2395: GenStage.consumer_dispatch/6
    (gen_stage) lib/gen_stage.ex:2574: GenStage.take_pc_events/3
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
```

Closes #466 