### PR TITLE
Solution: Remove Supervisor.Spec references

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ defmodule Acme.Application do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
       # This is the new line
       Acme.Scheduler

--- a/pages/supervision-tree.md
+++ b/pages/supervision-tree.md
@@ -12,4 +12,4 @@
 
 ## Error Handling
 
-The OTP Supervision Tree is initiated by the user of the library. Therefore the error handling can be implemented via normal OTP means. See `Supervisor.Spec` for more information.
+The OTP Supervision Tree is initiated by the user of the library. Therefore the error handling can be implemented via normal OTP means. See `Supervisor` module for more information.


### PR DESCRIPTION
The `import` statement is not necessary as noted in this issue: https://github.com/quantum-elixir/quantum-core/issues/474

Tested locally with a little dummy project - when the `warn: false` option was removed it confirmed that the import statement was unused:
```
warning: unused import Supervisor.Spec
  lib/acme/application.ex:9
  ```