### PR TITLE
feat: Use `:telemetry.span/3`

### DIFF
--- a/lib/quantum/executor.ex
+++ b/lib/quantum/executor.ex
@@ -96,7 +96,7 @@ defmodule Quantum.Executor do
       try do
         :telemetry.span([:quantum, :job], %{job: job, node: node, scheduler: scheduler}, fn ->
           result = execute_task(task)
-          {result, %{result: result}}
+          {result, %{job: job, node: node, scheduler: scheduler, result: result}}
         end)
       catch
         type, value ->

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,7 @@ defmodule Quantum.Mixfile do
     [
       {:crontab, "~> 1.1"},
       {:gen_stage, "~> 0.14 or ~> 1.0"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, ">= 0.4.3 and < 1.0.0"},
       {:tzdata, "~> 1.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev, :docs], runtime: false},
       {:excoveralls, "~> 0.5", only: [:test], runtime: false},

--- a/test/quantum/executor_test.exs
+++ b/test/quantum/executor_test.exs
@@ -53,6 +53,7 @@ defmodule Quantum.ExecutorTest do
         ) do
       send(parent_thread, %{
         test_id: test_id,
+        job_name: job_name,
         telemetry_span_context: telemetry_span_context,
         type: :stop
       })
@@ -62,6 +63,9 @@ defmodule Quantum.ExecutorTest do
           [:quantum, :job, :exception],
           %{duration: _duration} = _measurements,
           %{
+            job: %Job{name: job_name},
+            node: _node,
+            scheduler: _scheduler,
             kind: kind,
             reason: reason,
             stacktrace: stacktrace,
@@ -71,6 +75,7 @@ defmodule Quantum.ExecutorTest do
         ) do
       send(parent_thread, %{
         test_id: test_id,
+        job_name: job_name,
         telemetry_span_context: telemetry_span_context,
         type: :exception,
         kind: kind,

--- a/test/quantum/executor_test.exs
+++ b/test/quantum/executor_test.exs
@@ -42,7 +42,13 @@ defmodule Quantum.ExecutorTest do
     def handle_event(
           [:quantum, :job, :stop],
           %{duration: _duration} = _measurements,
-          %{result: _result, telemetry_span_context: telemetry_span_context} = _metadata,
+          %{
+            job: %Job{name: job_name},
+            node: _node,
+            scheduler: _scheduler,
+            result: _result,
+            telemetry_span_context: telemetry_span_context
+          } = _metadata,
           %{parent_thread: parent_thread, test_id: test_id}
         ) do
       send(parent_thread, %{


### PR DESCRIPTION
There doesn't seem to be a clear reason to not use the proper span function.

I figured I would do the legwork here.