### PR TITLE
Fix telemetry not support v1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,7 @@ defmodule Quantum.Mixfile do
     [
       {:crontab, "~> 1.1"},
       {:gen_stage, "~> 0.14 or ~> 1.0"},
-      {:telemetry, ">= 0.4.3 and < 1.0.0"},
+      {:telemetry, "~> 0.4.3 or ~> 1.0.0"},
       {:tzdata, "~> 1.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev, :docs], runtime: false},
       {:excoveralls, "~> 0.5", only: [:test], runtime: false},


### PR DESCRIPTION
The patch try to make this library support telemetry v1.0. Currently, it
doesn't because it contraint between [0.4.3, 1.0.0). Fix by using `or`
constraint to support both version.