### PR TITLE
Fix incorrect TaskSupervisor name in documentation

### DIFF
--- a/pages/supervision-tree.md
+++ b/pages/supervision-tree.md
@@ -6,8 +6,8 @@
     * `YourApp.Scheduler.JobBroadcaster` (`Quantum.JobBroadcaster`) - The `GenStage` that keeps track of all jobs.
     * `YourApp.Scheduler.ExecutionBroadcaster` (`Quantum.ExecutionBroadcaster`) - The `GenStage` that notifies execution of jobs.
     * `YourApp.Scheduler.ExecutorSupervisor` (`Quantum.ExecutorSupervisor`) - The `ConsumerSupervisor` that spawns an Executor for every execution.
-      - `no_name` (`YourApp.Scheduler.Executor`) - The `Task` that calls the `YourApp.Scheduler.Task.Supervisor` with the execution of the Cron (per Node).
-    * `YourApp.Scheduler.Task.Supervisor` (`Task.Supervisor`) - The `Task.Supervisor` where all Cron jobs run in.
+      - `no_name` (`YourApp.Scheduler.Executor`) - The `Task` that calls the `YourApp.Scheduler.TaskSupervisor` with the execution of the Cron (per Node).
+    * `YourApp.Scheduler.TaskSupervisor` (`Task.Supervisor`) - The `Task.Supervisor` where all Cron jobs run in.
       - `Task` - The place where the defined Cron job action gets called.
 
 ## Error Handling


### PR DESCRIPTION
In documentation mentioned that quantum will create `YourApp.Scheduler.Task.Supervisor` but
the correct one is `YourApp.Scheduler.TaskSupervisor`.