### PR TITLE
Allow 1.x.x upgrades for telemetry

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,7 @@ defmodule Quantum.Mixfile do
     [
       {:crontab, "~> 1.1"},
       {:gen_stage, "~> 0.14 or ~> 1.0"},
-      {:telemetry, "~> 0.4.3 or ~> 1.0.0"},
+      {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:tzdata, "~> 1.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev, :docs], runtime: false},
       {:excoveralls, "~> 0.5", only: [:test], runtime: false},


### PR DESCRIPTION
Very basic minor change to allow for a graceful upgrade path on minor versions. Thank you!