### PR TITLE
Solution: add a warning message and remove jobs with invalid tasks

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -320,7 +320,7 @@ defmodule Quantum do
       cond do
         duplicate_job?(Map.keys(acc), job) ->
           Logger.warn(
-            "Job with name '#{name}' of scheduler '#{scheduler}' not started due to duplicate job name"
+            "Job with name '#{name}' of scheduler '#{scheduler}' not started: duplicate job name"
           )
 
           acc

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -43,7 +43,6 @@ defmodule QuantumStartupTest do
         test_jobs = [
           {:existing_function, [schedule: ~e[2 * * * *], task: {IO, :puts, ["hey"]}]},
           {:another_existing_function, [schedule: ~e[2 * * * *], task: {Kernel, :floor, [5.4]}]},
-          {:existing_function, [schedule: ~e[2 * * * *], task: {IO, :puts, ["hey"]}]},
           {:inexistent_function,
            [schedule: ~e[2 * * * *], task: {UndefinedModule, :undefined_function, ["argument"]}]}
         ]

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -35,4 +35,28 @@ defmodule QuantumStartupTest do
       :ok = stop_supervised(Scheduler)
     end)
   end
+
+  @tag :startup
+  test "prevent unexported functions on startup" do
+    log =
+      capture_log(fn ->
+        test_jobs = [
+          {:existing_function, [schedule: ~e[2 * * * *], task: {IO, :puts, ["hey"]}]},
+          {:another_existing_function, [schedule: ~e[2 * * * *], task: {Kernel, :floor, [5.4]}]},
+          {:existing_function, [schedule: ~e[2 * * * *], task: {IO, :puts, ["hey"]}]},
+          {:inexistent_function,
+           [schedule: ~e[2 * * * *], task: {UndefinedModule, :undefined_function, ["argument"]}]}
+        ]
+
+        Application.put_env(:quantum, QuantumStartupTest.Scheduler, jobs: test_jobs)
+
+        start_supervised!(Scheduler)
+
+        assert Enum.count(QuantumStartupTest.Scheduler.jobs()) == 2
+        :ok = stop_supervised(Scheduler)
+      end)
+
+    assert log =~
+             "Job with name 'inexistent_function' of scheduler 'Elixir.QuantumStartupTest.Scheduler' not started: invalid task function"
+  end
 end


### PR DESCRIPTION
Hello!

**Proposal**:

At Quantum startup, when detected that a `mfa` `task` is not a  valid function, ignore the `job` configuration and show a `warning` message.

closes #507