### PR TITLE
Changes warn to error when the function `check_node?` fails

### DIFF
--- a/lib/quantum/node_selector_broadcaster.ex
+++ b/lib/quantum/node_selector_broadcaster.ex
@@ -81,7 +81,7 @@ defmodule Quantum.NodeSelectorBroadcaster do
     if running_node?(node, task_supervisor) do
       true
     else
-      Logger.warn(
+      Logger.error(
         "Node #{inspect(node)} is not running. Job #{inspect(job_name)} could not be executed."
       )
 


### PR DESCRIPTION
When the running_node? function fails, only a warning log is returned. However, since the process is not executed due to a connection error, shouldn't this warning be an error?

This PR changes this warning to error so that the connection failure and the process not running are properly notified.