### PR TITLE
Fix calls to deprecated Logger.warn/2

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -319,14 +319,14 @@ defmodule Quantum do
     |> Enum.reduce(%{}, fn %Job{name: name} = job, acc ->
       cond do
         duplicate_job?(Map.keys(acc), job) ->
-          Logger.warn(
+          Logger.warning(
             "Job with name '#{name}' of scheduler '#{scheduler}' not started: duplicate job name"
           )
 
           acc
 
         invalid_job_task?(job) ->
-          Logger.warn(
+          Logger.warning(
             "Job with name '#{name}' of scheduler '#{scheduler}' not started: invalid task function"
           )
 

--- a/lib/quantum/date_library.ex
+++ b/lib/quantum/date_library.ex
@@ -29,7 +29,7 @@ defmodule Quantum.DateLibrary do
           raise InvalidTimezoneError
 
         {:error, :utc_only_time_zone_database} ->
-          Logger.warn("Timezone database not set up")
+          Logger.warning("Timezone database not set up")
           raise InvalidTimezoneError
       end
 
@@ -38,7 +38,7 @@ defmodule Quantum.DateLibrary do
         DateTime.to_naive(dt)
 
       {:error, :utc_only_time_zone_database} ->
-        Logger.warn("Timezone database not set up")
+        Logger.warning("Timezone database not set up")
         raise InvalidTimezoneError
     end
   end
@@ -61,7 +61,7 @@ defmodule Quantum.DateLibrary do
         raise InvalidTimezoneError
 
       {:error, :utc_only_time_zone_database} ->
-        Logger.warn("Timezone database not set up")
+        Logger.warning("Timezone database not set up")
         raise InvalidTimezoneError
     end
   end

--- a/lib/quantum/execution_broadcaster.ex
+++ b/lib/quantum/execution_broadcaster.ex
@@ -247,7 +247,7 @@ defmodule Quantum.ExecutionBroadcaster do
         add_to_state(state, time, date, job)
 
       {:error, _} ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           """
           Invalid Schedule #{inspect(schedule)} provided for job #{inspect(name)}.
           No matching dates found. The job was removed.
@@ -284,7 +284,7 @@ defmodule Quantum.ExecutionBroadcaster do
     _ in InvalidDateTimeForTimezoneError ->
       next_time = NaiveDateTime.add(time, 60, :second)
 
-      Logger.warn(fn ->
+      Logger.warning(fn ->
         """
         Next execution time for job #{inspect(name)} is not a valid time.
         Retrying with #{inspect(next_time)}


### PR DESCRIPTION
`Logger.warn/2` has been deprecated in Elixir 1.15.