### PR TITLE
fix problem with non-exported function

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -342,8 +342,11 @@ defmodule Quantum do
   defp duplicate_job?(existent_jobs, %Job{name: name}), do: Enum.member?(existent_jobs, name)
 
   defp invalid_job_task?(%Job{task: {m, f, args}})
-       when is_atom(m) and is_atom(f) and is_list(args),
-       do: not (Code.ensure_loaded?(m) && function_exported?(m, f, length(args)))
+       when is_atom(m) and is_atom(f) and is_list(args) do
+    if Code.ensure_loaded?(m),
+      do: not function_exported?(m, f, length(args)),
+      else: true
+  end
 
   defp invalid_job_task?(_), do: false
 

--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -343,7 +343,7 @@ defmodule Quantum do
 
   defp invalid_job_task?(%Job{task: {m, f, args}})
        when is_atom(m) and is_atom(f) and is_list(args),
-       do: not function_exported?(m, f, length(args))
+       do: not (Code.ensure_loaded?(m) && function_exported?(m, f, length(args)))
 
   defp invalid_job_task?(_), do: false
 


### PR DESCRIPTION
We had a problem where Quantum could only schedule a job right after executing `mix clean`, but with every call to `mix` after that, our configured jobs were not scheduled, because `function_exported?/3` returned false, even though the function still existed, but apparently was not yet exported at the time the Quantum code executed. This PR fixes this by calling `Code.ensure_loaded?/1` before `function_exported?/3`, which actively tries to load the module before returning `true` if this was successful or `false` otherwise (e.g. if the module does not exist).