### PR TITLE
feat: string job names

### DIFF
--- a/lib/quantum.ex
+++ b/lib/quantum.ex
@@ -423,31 +423,31 @@ defmodule Quantum do
 
       @impl behaviour
       def deactivate_job(server \\ __job_broadcaster__(), name)
-          when is_atom(name) or is_reference(name) do
+          when is_atom(name) or is_reference(name) or is_binary(name) do
         GenStage.cast(server, {:change_state, name, :inactive})
       end
 
       @impl behaviour
       def activate_job(server \\ __job_broadcaster__(), name)
-          when is_atom(name) or is_reference(name) do
+          when is_atom(name) or is_reference(name) or is_binary(name) do
         GenStage.cast(server, {:change_state, name, :active})
       end
 
       @impl behaviour
       def run_job(server \\ __job_broadcaster__(), name)
-          when is_atom(name) or is_reference(name) do
+          when is_atom(name) or is_reference(name) or is_binary(name) do
         GenStage.cast(server, {:run_job, name})
       end
 
       @impl behaviour
       def find_job(server \\ __job_broadcaster__(), name)
-          when is_atom(name) or is_reference(name) do
+          when is_atom(name) or is_reference(name) or is_binary(name) do
         GenStage.call(server, {:find_job, name}, __timeout__())
       end
 
       @impl behaviour
       def delete_job(server \\ __job_broadcaster__(), name)
-          when is_atom(name) or is_reference(name) do
+          when is_atom(name) or is_reference(name) or is_binary(name) do
         GenStage.cast(server, {:delete, name})
       end
 

--- a/lib/quantum/job.ex
+++ b/lib/quantum/job.ex
@@ -25,7 +25,7 @@ defmodule Quantum.Job do
     state: :active
   ]
 
-  @type name :: atom | reference()
+  @type name :: atom | reference() | String.t()
   @type state :: :active | :inactive
   @type task :: {atom, atom, [any]} | (-> any)
   @type timezone :: :utc | String.t()
@@ -81,6 +81,7 @@ defmodule Quantum.Job do
 
   """
   @spec set_name(t, atom) :: t
+  def set_name(%__MODULE__{} = job, name) when is_binary(name), do: Map.put(job, :name, name)
   def set_name(%__MODULE__{} = job, name) when is_atom(name), do: Map.put(job, :name, name)
   def set_name(%__MODULE__{} = job, name) when is_reference(name), do: Map.put(job, :name, name)
 

--- a/test/quantum_startup_test.exs
+++ b/test/quantum_startup_test.exs
@@ -17,6 +17,7 @@ defmodule QuantumStartupTest do
   test "prevent duplicate job names on startup" do
     capture_log(fn ->
       test_jobs = [
+        {"test_job", [schedule: ~e[1 * * * *], task: fn -> :ok end]},
         {:test_job, [schedule: ~e[1 * * * *], task: fn -> :ok end]},
         {:test_job, [schedule: ~e[2 * * * *], task: fn -> :ok end]},
         {:inactive_job, [schedule: ~e[* * * * *], task: fn -> :ok end, state: :inactive]},


### PR DESCRIPTION
This PR adds in string names for quantum jobs.
Using atom names is inherently not scalable due to memory concerns when dealing with large number of alerts.